### PR TITLE
Update Templates

### DIFF
--- a/plugin/backends.py
+++ b/plugin/backends.py
@@ -4,7 +4,6 @@ from .exceptions import UnknownClassException
 
 
 backend_template = """
-## {name}
 Tables implemented:
 
 {contracts}

--- a/plugin/backends.py
+++ b/plugin/backends.py
@@ -5,6 +5,7 @@ from .exceptions import UnknownClassException
 
 backend_template = """
 ## {name}
+Tables implemented:
 
 {contracts}
 """
@@ -16,7 +17,7 @@ def render_backend(data, match):
     if backend_data is None:
         raise UnknownClassException(f"Unknown class: {match}")
 
-    contracts = ", ".join(f"`{c}`" for c in backend_data["tables"])
+    contracts = "\n".join(f"* `{c}`" for c in backend_data["tables"])
 
     return backend_template.format(
         name=backend_data["name"],

--- a/plugin/backends.py
+++ b/plugin/backends.py
@@ -16,7 +16,7 @@ def render_backend(data, match):
     if backend_data is None:
         raise UnknownClassException(f"Unknown class: {match}")
 
-    contracts = "\n".join(f"* `{c}`" for c in backend_data["tables"])
+    contracts = "\n".join(f"* `{c}`" for c in sorted(backend_data["tables"]))
 
     return backend_template.format(
         name=backend_data["name"],

--- a/plugin/backends.py
+++ b/plugin/backends.py
@@ -16,7 +16,10 @@ def render_backend(data, match):
     if backend_data is None:
         raise UnknownClassException(f"Unknown class: {match}")
 
-    contracts = "\n".join(f"* `{c}`" for c in sorted(backend_data["tables"]))
+    contracts = "\n".join(
+        f"* [`{c}`](contracts-reference.md#{c.lower()})"
+        for c in sorted(backend_data["tables"])
+    )
 
     return backend_template.format(
         name=backend_data["name"],

--- a/plugin/contracts.py
+++ b/plugin/contracts.py
@@ -8,6 +8,8 @@ contract_template = """
 
 {docstring}
 
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
 {columns}
 
 
@@ -22,10 +24,14 @@ def render_contract(data, match):
         raise UnknownClassException(f"Unknown class: {match}")
 
     docstring = "\n".join(contract_data["docstring"])
+    columns = "\n".join(
+        f"| {c['name']} | {c['description']} | {c['type']} | {', '.join(c['constraints'])}. |"
+        for c in contract_data["columns"]
+    )
 
     return contract_template.format(
         name=contract_data["name"],
         docstring=docstring,
-        columns="",
+        columns=columns,
         backend_support="",
     ).strip()

--- a/plugin/contracts.py
+++ b/plugin/contracts.py
@@ -25,7 +25,7 @@ def render_contract(data, match):
 
     docstring = "\n".join(contract_data["docstring"])
     columns = "\n".join(
-        f"| {c['name']} | {c['description']} | {c['type']} | {', '.join(c['constraints'])}. |"
+        f"| {c['name']} | {c['description']} | {c['type']} | {', '.join(c['constraints']).capitalize()}. |"
         for c in contract_data["columns"]
     )
 

--- a/tests/data.json
+++ b/tests/data.json
@@ -14,7 +14,15 @@
       "name": "DummyClass",
       "dotted_path": "dummy_module.DummyClass",
       "docstring": ["Dummy docstring"],
-      "columns": [],
+      "columns": [{
+        "name": "patient_id",
+        "description": "a column description",
+        "type": "PseudoPatientId",
+        "constraints": [
+          "Must have a value",
+          "Must be unique"
+        ]
+      }],
       "backend_support": []
     },
     {

--- a/tests/plugin/test_main.py
+++ b/tests/plugin/test_main.py
@@ -31,7 +31,7 @@ Dummy docstring
 
 | Column name | Description | Type | Constraints |
 | ----------- | ----------- | ---- | ----------- |
-| patient_id | a column description | PseudoPatientId | Must have a value, Must be unique. |
+| patient_id | a column description | PseudoPatientId | Must have a value, must be unique. |
 
 ## DummyClass2
 
@@ -85,7 +85,7 @@ Dummy docstring
 
 | Column name | Description | Type | Constraints |
 | ----------- | ----------- | ---- | ----------- |
-| patient_id | a column description | PseudoPatientId | Must have a value, Must be unique. |
+| patient_id | a column description | PseudoPatientId | Must have a value, must be unique. |
 
 Tables implemented:
 

--- a/tests/plugin/test_main.py
+++ b/tests/plugin/test_main.py
@@ -29,13 +29,18 @@ def test_multiple_paths_to_change(monkeypatch):
 
 Dummy docstring
 
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| patient_id | a column description | PseudoPatientId | Must have a value, Must be unique. |
+
 ## DummyClass2
 
 Dummy docstring2.
 
 Second line.
 
-## DummyBackend1
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
 
 Tables implemented:
 
@@ -78,7 +83,9 @@ def test_one_path_to_change(monkeypatch):
 
 Dummy docstring
 
-## DummyBackend1
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| patient_id | a column description | PseudoPatientId | Must have a value, Must be unique. |
 
 Tables implemented:
 

--- a/tests/plugin/test_main.py
+++ b/tests/plugin/test_main.py
@@ -37,11 +37,14 @@ Second line.
 
 ## DummyBackend1
 
-`DummyClass`, `DummyClass2`
+Tables implemented:
 
-## DummyBackend2
+* `DummyClass`
+* `DummyClass2`
 
-`DummyClass`
+Tables implemented:
+
+* `DummyClass`
     """
 
     assert output == expected
@@ -77,7 +80,10 @@ Dummy docstring
 
 ## DummyBackend1
 
-`DummyClass`, `DummyClass2`
+Tables implemented:
+
+* `DummyClass`
+* `DummyClass2`
     """
 
     assert output == expected

--- a/tests/plugin/test_main.py
+++ b/tests/plugin/test_main.py
@@ -44,12 +44,12 @@ Second line.
 
 Tables implemented:
 
-* `DummyClass`
-* `DummyClass2`
+* [`DummyClass`](contracts-reference.md#dummyclass)
+* [`DummyClass2`](contracts-reference.md#dummyclass2)
 
 Tables implemented:
 
-* `DummyClass`
+* [`DummyClass`](contracts-reference.md#dummyclass)
     """
 
     assert output == expected
@@ -89,8 +89,8 @@ Dummy docstring
 
 Tables implemented:
 
-* `DummyClass`
-* `DummyClass2`
+* [`DummyClass`](contracts-reference.md#dummyclass)
+* [`DummyClass2`](contracts-reference.md#dummyclass2)
     """
 
     assert output == expected


### PR DESCRIPTION
This updates the backend and contracts templates to match our [intended outputs](https://github.com/opensafely-core/databuilder/issues/191#issuecomment-958936266):

### Backends
* Removed the class name, setting this in the markdown manually is clearer
* Listed implemented Contracts as a list

![](https://p198.p4.n0.cdn.getcloudapp.com/items/llu6Ld7e/dc5339be-5ef8-4a5c-b8b0-cce2b5cf34b5.jpg?v=5bc1006001a99b6e8b78d44d37251c14)

### Contracts
* Listed columns as a table now that we're exporting them from databuilder

![](https://p198.p4.n0.cdn.getcloudapp.com/items/p9uXJQOx/e11d05af-9400-4b7b-a696-3fb89de7dcaa.jpg?v=e47c5c3b5c48e99159f219cf20eb652a)